### PR TITLE
Remove white bar when walking on y axis

### DIFF
--- a/src/levelblit.c
+++ b/src/levelblit.c
@@ -1549,7 +1549,7 @@ void DrawLevel(int off_x, int off_y, int hide_not_visited, int fog_of_war)
 		}
 	}
 
-	for (y = 0; y < SCREEN_H/32 + 1; y++) {
+	for (y = 0; y < SCREEN_H/32 + 2; y++) {
 		for (x = 0; x < SCREEN_W/32 + 1; x++) {
 			resolve_x = x + (off_x/32);
 			resolve_y = y + (off_y/32);


### PR DESCRIPTION
Every 128 pixels walked on the y axis a white line appears at the bottom of the screen as no extra tile has been drawn. Lets add one.
